### PR TITLE
Update exits to latest paradigm

### DIFF
--- a/pysyte/cli/exits.py
+++ b/pysyte/cli/exits.py
@@ -2,43 +2,51 @@ from dataclasses import dataclass
 
 from pysyte import os
 
+OK = os.EX_OK
+FAIL = os.EX_FAIL
 
 def exits():
-    import os
-    return {k:v for k, v in os.globals().items() if k.startswith("EX_")}
+    """All the EX_* symbols in the os module, by name
+
+    >>> x = exits()
+    >>> assert x["EX_OK"] == 0
+    """
+    return {_: getattr(os, _) for _ in dir(os) if 'EX_' in _}
+
 
 
 @dataclass
 class ExitCode:
-    exit_code: int = os.EX_OK
+    code: int = OK
 
     def __post_init__(self):
         self.exit = self.string()
 
     def __int__(self) -> int:
-        return self.exit_code
+        return self.code
 
     def __str__(self):
-        return self.exit
+        return self.name
+
+    def raise(self, message: str = "") -> None:
+        raise SystemExit(self.code, message) if message else SystemExit(self.code)
 
     @property
     def ok(self):
-        return self.exit_code == os.EX_OK
+        return self.code == OK
 
     @property
     def errors(self):
         return not self.ok
 
-    def string(self) -> str:
-        if self.ok:
-            return "EX_OK"
-
-        for ex_name, code in exits().items():
-            if code == self.exit_code:
-                return ex_name
-        exit = self.exit_code
-        return f"{exit=}"
+    @property
+    def name(self) -> str:
+        for name, code in exits().items():
+            if code == self.code:
+                return name
+        code = self.code
+        return f"{code=}"
 
 
-pass_ = os.ExitCode(os.EX_OK)
-fail = os.ExitCode(os.EX_FAIL)
+ok = ExitCode(OK)
+fail = ExitCode(FAIL)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
• Refactor ExitCode class with improved API and naming
• Add docstring and doctests for exits() function
• Replace string() method with name property
• Add raise() method for SystemExit handling


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>exits.py</strong><dd><code>Refactor ExitCode class with improved API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pysyte/cli/exits.py

• Add module-level OK and FAIL constants from os module<br> • Refactor <br>exits() function with docstring and improved implementation<br> • Rename <br>exit_code parameter to code in ExitCode class<br> • Replace string() <br>method with name property and add raise() method<br> • Update module-level <br>instances from pass_/fail to ok/fail


</details>


  </td>
  <td><a href="https://github.com/jalanb/pysyte/pull/76/files#diff-b2f3bfe6505e85dfe0443deae43f1504465a8f8616e53c01c74d161c220ab616">+25/-17</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

## Summary by Sourcery

Refactor the exits module to modernize the ExitCode API and constants, improve the exits() lookup function with documentation, and rename default instances

Enhancements:
- Introduce module-level OK and FAIL constants for os.EX_OK and os.EX_FAIL
- Revamp exits() to dynamically collect EX_* symbols with a docstring and doctests
- Rename ExitCode.exit_code to code, simplify its __int__ and __str__, and replace string() with a name property
- Add a raise() method to ExitCode for direct SystemExit handling
- Rename default exit code instances from pass_/fail to ok/fail